### PR TITLE
add ADB2C authentication

### DIFF
--- a/Services/gabMileage.Mileage.Api/DelegatedPermissions.cs
+++ b/Services/gabMileage.Mileage.Api/DelegatedPermissions.cs
@@ -1,0 +1,13 @@
+﻿namespace gabMileage.Mileage.Api;
+
+internal static class DelegatedPermissions
+{
+    public const string PomodoroRead = "mileage.read";
+    public const string PomodoroWrite = "mileage.write";
+
+    public static string?[] All => typeof(DelegatedPermissions)
+        .GetFields()
+        .Where(f => f.Name != nameof(All))
+        .Select(f => f.GetValue(null) as string)
+        .ToArray();
+}

--- a/Services/gabMileage.Mileage.Api/GlobalSuppressions.cs
+++ b/Services/gabMileage.Mileage.Api/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Usage", "MA0004:Use Task.ConfigureAwait(false)", Justification = "<Pending>")]

--- a/Services/gabMileage.Mileage.Api/ProgramExtensions.cs
+++ b/Services/gabMileage.Mileage.Api/ProgramExtensions.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Identity.Web;
+using Microsoft.IdentityModel.JsonWebTokens;
+using NJsonSchema.Generation.TypeMappers;
+using NJsonSchema;
+using NSwag;
+using NSwag.AspNetCore;
+using NSwag.Generation.Processors.Security;
+using trakUtility.api;
+
+namespace gabMileage.Mileage.Api;
+
+public static class ProgramExtensions
+{
+    private const string AppName = "GabMileage - MileageApi";
+
+    public static void AddCustomSwagger(this WebApplicationBuilder builder, SwaggerAuthenticationOptions authenticationOptions)
+    {
+
+        builder.Services.AddEndpointsApiExplorer();
+
+        builder.Services.AddOpenApiDocument(document =>
+        {
+            document.Version = "v1";
+            document.Title = $"{AppName}";
+            document.SchemaSettings.AllowReferencesWithProperties = true;
+            document.SchemaSettings.GenerateAbstractProperties = true;
+
+            document.AddSecurity("bearer", Enumerable.Empty<string>(), new OpenApiSecurityScheme
+            {
+                Type = OpenApiSecuritySchemeType.OAuth2,
+                Description = "B2C authentication",
+                Flow = OpenApiOAuth2Flow.Implicit,
+                Flows = new OpenApiOAuthFlows()
+                {
+                    Implicit = new OpenApiOAuthFlow()
+                    {
+                        Scopes = DelegatedPermissions.All.ToDictionary(p => $"{authenticationOptions.ApplicationIdUri}/{p}", StringComparer.OrdinalIgnoreCase),
+                        AuthorizationUrl = authenticationOptions.AuthorizationUrl,
+                        TokenUrl = authenticationOptions.TokenUrl,
+                    },
+                }
+            });
+
+            document.OperationProcessors.Add(new AspNetCoreOperationSecurityScopeProcessor("bearer"));
+        });
+    }
+
+    public static void AddCustomAuthentication(this WebApplicationBuilder builder)
+    {
+        builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddMicrosoftIdentityWebApi(options =>
+                {
+                    builder.Configuration.Bind("AzureAdB2C", options);
+
+                    options.MapInboundClaims = false;
+                    options.TokenValidationParameters.NameClaimType = "name";
+                },
+                options => { builder.Configuration.Bind("AzureAdB2C", options); });
+    }
+
+    public static void AddCustomAuthorization(this WebApplicationBuilder builder)
+    {
+    }
+
+    public static void UseCustomSwagger(this WebApplication app, SwaggerAuthenticationOptions authenticationOptions)
+    {
+        app.UseOpenApi();
+        app.UseSwaggerUi(settings =>
+        {
+            settings.OAuth2Client = new OAuth2ClientSettings
+            {
+                ClientId = authenticationOptions.ClientId,
+                AppName = authenticationOptions.AppName,
+            };
+        });
+    }
+}

--- a/Services/gabMileage.Mileage.Api/appsettings.json
+++ b/Services/gabMileage.Mileage.Api/appsettings.json
@@ -1,4 +1,24 @@
 {
+  "AzureAdB2C": {
+    "Instance": "https://trakstudio.b2clogin.com/",
+    "Domain": "trakstudio.onmicrosoft.com",
+    "TenantId": "41684cb7-de3a-4321-99ae-21e719950823",
+    "ClientId": "13b3adef-ad05-4a13-9e59-cdcfec45c76f",
+    "CallbackPath": "/signin-oidc",
+    "SignUpSignInPolicyId": "B2C_1_trakpokersignin1",
+    "SignedOutCallbackPath": "/signout/B2C_1_susi",
+    "ResetPasswordPolicyId": "b2c_1_reset",
+    "EditProfilePolicyId": "b2c_1_edit_profile",
+    "EnablePiiLogging": true
+  },
+  "SwaggerAuthentication": {
+    "Authority": "https://trakstudio.b2clogin.com",
+    "AuthorizationUrl": "https://trakstudio.b2clogin.com/trakstudio.onmicrosoft.com/B2C_1_trakpokersignin1/oauth2/v2.0/authorize",
+    "TokenUrl": "https://trakstudio.b2clogin.com/trakstudio.onmicrosoft.com/B2C_1_trakpokersignin1/oauth2/v2.0/token",
+    "ClientId": "bf70be56-36a9-4de5-996a-ef1b366f8d53",
+    "ApplicationIdUri": "https://trakstudio.onmicrosoft.com/13b3adef-ad05-4a13-9e59-cdcfec45c76f",
+    "AppName": "TrakSwaggerUI"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/Services/gabMileage.Mileage.Api/gabMileage.Mileage.Api.csproj
+++ b/Services/gabMileage.Mileage.Api/gabMileage.Mileage.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -8,13 +8,24 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Carter" Version="8.0.0" />
     <PackageReference Include="Dapr.AspNetCore" Version="1.12.0" />
     <PackageReference Include="Dapr.Extensions.Configuration" Version="1.12.0" />
+    <PackageReference Include="FluentValidation" Version="11.9.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
+    <PackageReference Include="MediatR" Version="12.2.0" />
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.132">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="2.16.0" />
+    <PackageReference Include="NSwag.AspNetCore" Version="14.0.0-preview012" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\TrakUtility\trakUtility.api\trakUtility.api.csproj" />
+    <ProjectReference Include="..\..\..\TrakUtility\TrakUtility.data\TrakUtility.data.csproj" />
     <ProjectReference Include="..\..\gabMileage.ServiceDefaults\gabMileage.ServiceDefaults.csproj" />
     <ProjectReference Include="..\..\Integration\gabMileage.IntegrationTypes\gabMileage.IntegrationTypes.csproj" />
   </ItemGroup>


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Pull Request Description
> 
> ## TL;DR
> This pull request adds authentication and authorization using Azure AD B2C.
> 
> ## What changed
> - Added "DelegatedPermissions.cs" file with constants for delegated permissions related to mileage.
> - Added "GlobalSuppressions.cs" file for code analysis with a comment.
> - Added code to suppress a specific message related to the usage of Task.ConfigureAwait(false).
> - Imported various namespaces.
> - Added using statements for different libraries and namespaces.
> - Created a web application builder and added service defaults.
> - Added Dapr client to the services.
> - Added Dapr secret store and configured Swagger/OpenAPI.
> - Retrieved authentication options from the configuration and threw an exception if they are null.
> - Added a CORS policy that allows any origin, method, and header.
> - Added custom Swagger, authentication, and authorization services.
> - Added MediatR services with scoped lifetime and registered services from the current assembly.
> - Added controllers to the services.
> - Commented out code to add a DbContext with a SQL Server connection string.
> - Added a new file called "ProgramExtensions.cs" with a reference to the JwtBearer authentication scheme.
> - Added custom Swagger documentation to a web application using an extension method.
> - Added OpenAPI documentation to a builder object, setting the version and title of the document, allowing references with properties, and generating abstract properties.
> - Added a security scheme for B2C authentication using OAuth2 with an implicit flow, and set the scopes and authorization URL.
> - Configured authentication options, set the authorization and token URLs, and added an operation security scope processor for custom authentication and authorization.
> - Added custom authentication and authorization services using Microsoft Identity Web API and Azure AD B2C.
> - Added methods for adding custom authorization, using custom Swagger, and binding Azure AD B2C settings from the appsettings.json file.
> - Updated the appsettings.json file with configurations for Azure AD B2C authentication and Swagger authentication.
> - Updated the logging level and added a package reference for Carter version 8.0.0.
> - Updated package references, removing "Swashbuckle.AspNetCore" and adding "Microsoft.Identity.Web.UI" and "NSwag.AspNetCore".
> - Added project references for "trakUtility.api" and "TrakUtility.data".
> 
> ## How to test
> - No specific testing instructions provided.
> 
> ## Why make this change
> - The changes were made to add functionality for authentication and authorization using Azure AD B2C.
</details>